### PR TITLE
Update documentation on stat events

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,50 @@ with the calculated path - e.g. `callback("/home/"+username)`.  *TODO* - Error
 management here!
 
 `.on("stat",function (path,statkind,statresponder) { })` - on any of STAT, LSTAT, or FSTAT
-requests (the type will be passed in "statkind"). Return the status using
-`statresponder({mode: , uid:, gid: size: atime:, mtime: })`. Or use any of the 
-error methods in [Error Callbacks](#error-callbacks) below
-  
+requests (the type will be passed in "statkind"). The statresponder object is a `Statter`
+object from the source code. Communicate status back by calling methods and setting properties
+on the object like this:
+
+#### Directory
+```js
+session.on('stat', function(path, statkind, statresponder) {
+    statresponder.is_directory();    // Tells statresponder that we're describing a directory.
+    statresponder.permissions = 755; // Octal permissions, like what you'd send to a chmod command
+    statresponder.uid = 1;           // User ID that owns the file.
+    statresponder.gid = 1;           // Group ID that owns the file.
+    statresponder.size = 0;          // File size in bytes.
+    statresponder.atime = 123456;    // Created at (unix style timestamp in seconds-from-epoch).
+    statresponder.mtime = 123456;    // Modified at (unix style timestamp in seconds-from-epoch).
+
+    stat.file();   // Tells the statter to actually send the values above down the wire.
+});
+```
+
+#### File
+```js
+session.on('stat', function(path, statkind, statresponder) {
+    statresponder.is_file();         // Tells statresponder that we're describing a file.
+    statresponder.permissions = 644; // Octal permissions, like what you'd send to a chmod command
+    statresponder.uid = 1;           // User ID that owns the file.
+    statresponder.gid = 1;           // Group ID that owns the file.
+    statresponder.size = 1234;       // File size in bytes.
+    statresponder.atime = 123456;    // Created at (unix style timestamp in seconds-from-epoch).
+    statresponder.mtime = 123456;    // Modified at (unix style timestamp in seconds-from-epoch).
+
+    stat.file();   // Tells the statter to actually send the values above down the wire.
+});
+```
+
+#### Errors
+
+You can also respond with file not found messages like this:
+
+```js
+session.on('stat', function(path, statkind, statresponder) {
+    statresponder.noFile(); // Tells the statter to send a file not found stat down the wire.
+});
+```
+
 `.on("readdir",function (path,directory_emitter) { })` - on a directory listing attempt, the
 directory_emitter will keep emitting `dir` messages with a `responder` as a
 parameter, allowing you to respond with `responder.file(filename)` to return

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -170,10 +170,7 @@ var Statter = (function() {
     return this.type = constants.S_IFDIR;
   };
 
-  Statter.prototype.file = function(attrs) {
-    if (attrs == null) {
-      attrs = {};
-    }
+  Statter.prototype.file = function() {
     return this.sftpStream.attrs(this.reqid, this._get_statblock());
   };
 


### PR DESCRIPTION
I was having the same issue as stated in #12, so I decided to go ahead and supply some documentation.

This PR also removes the `attrs` parameter from the `file()` method as it lead me down the path of thinking I should pass the attributes into the method, when the code was ignoring whatever was passed in anyway.

Let me know if there's anything you'd like to change and I'm happy to help.