### PR TITLE
Fix for stream corruption and event emitter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ var myserver = new SFTPServer({
 The `debug` option turns on console logging for SSH2 streams so you can see what's going on under the
 hood to help debug authentication problems, or other low level issues you may encounter. 
 
+### temporary files
+
+The server stores temporary files while users are downloading. These are handled by the [tmp library](https://www.npmjs.com/package/tmp).
+Permissions for these files are set to 600 (read and write for the node user, no permission for any other users) and 
+are stored in your platform's default temporary file location. You can control which directory these files appear in
+by passing the `temporaryFileDirectory` to the constructor like this:
+
+```js
+var myserver = new SFTPServer({
+    privateKeyFile: "path_to_private_key_file",
+    temporaryFileDirectory: "/some/temporary/file/path/here"
+});
+```
+
 ### methods 
 ```js
 .listen(portnumber)

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -9,6 +9,7 @@ var ssh2_stream = require('ssh2-streams');
 var SFTP = ssh2_stream.SFTPStream;
 
 var tmp = require('tmp');
+tmp.setGracefulCleanup();
 
 var Readable = require('stream').Readable;
 var Writable = require('stream').Writable;

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -121,6 +121,8 @@ var SFTPServer = (function(superClass) {
   extend(SFTPServer, superClass);
 
   function SFTPServer(options) {
+    // Expose options for the other classes to read.
+    SFTPServer.options = options;
     var privateKey = (options && options.privateKeyFile) ? options.privateKeyFile : options; // Original constructor had just a privateKey string, so this preserves backwards compatibility.
     if (options && options.debug) {
       debug = function(msg) { console.log(msg); };
@@ -332,7 +334,9 @@ var SFTPSession = (function(superClass) {
     switch (stringflags) {
       case "r":
         // Create a temporary file to hold stream contents.
-        return tmp.file(function (err, tmpPath, fd) {
+        var options = {};
+        if (SFTPServer.options.temporaryFileDirectory) options.dir = SFTPServer.options.temporaryFileDirectory;
+        return tmp.file(options, function (err, tmpPath, fd) {
           if (err) throw err;
           handle = this.fetchhandle();
           this.handles[handle] = {

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -122,13 +122,14 @@ var SFTPServer = (function(superClass) {
 
   function SFTPServer(options) {
     // Expose options for the other classes to read.
-    SFTPServer.options = options;
-    var privateKey = (options && options.privateKeyFile) ? options.privateKeyFile : options; // Original constructor had just a privateKey string, so this preserves backwards compatibility.
-    if (options && options.debug) {
+    if (!options) options = { privateKeyFile: 'ssh_host_rsa_key' };
+    if (typeof options === 'string') options = { privateKeyFile: options }; // Original constructor had just a privateKey string, so this preserves backwards compatibility.
+    if (options.debug) {
       debug = function(msg) { console.log(msg); };
     }
+    SFTPServer.options = options;
     this.server = new ssh2.Server({
-      privateKey: fs.readFileSync(privateKey || 'ssh_host_rsa_key'),
+      privateKey: fs.readFileSync(options.privateKeyFile)
     }, (function(_this) {
       return function(client, info) {
         client.on('authentication', function(ctx) {

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -345,12 +345,10 @@ var SFTPSession = (function(superClass) {
           buffer: Buffer.alloc(0)
         };
         this.emit("readfile", pathname, ts);
-
-        ts.on("data", function (data) {
-          let buffer = this.handles[handle].buffer;
+        ts.on("data", function(data) {
+          var buffer = this.handles[handle].buffer;
           this.handles[handle].buffer = Buffer.concat([buffer, data], buffer.length + data.length);
         }.bind(this));
-
         return this.sftpStream.handle(reqid, handle);
       case "w":
         rs = new Readable();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "ISC",
   "dependencies": {
     "ssh2": "^0.4.13",
-    "ssh2-streams": "0.0.21"
+    "ssh2-streams": "^0.0.21",
+    "tmp": "^0.0.30"
   },
   "bugs": {
     "url": "https://github.com/BriteVerify/node-sftp-server/issues"


### PR DESCRIPTION
This should be a fix for both #19 as well as #9.

It changes the `READ` method from sequentially reading through the stream regardless of the requested offsets to the following:

- Create a write stream from a temporary file, pass that to the consumer of the library.
- On each read call, see if there's enough data in the temp file, if so, serve it, otherwise `setTimeout` to delay until there's potentially more data in the buffer.
- Once stream is at EOF, serve up the last chunks of data, then emit an EOF.

The temporary file is cleaned up automatically by the `tmp` library.

This is the best way I could figure out to allow random access to chunks of the file so that it wouldn't matter what order they got served up in. I tried to keep it in memory and slice the front of the buffer off, but again because of our random ordering of requests as they come through that resulted in a corrupted stream.

Let me know if you have any suggested changes, I'm happy to help.