### PR TITLE
Now passing SFTP stream to Responder so it can respond correctly.

### DIFF
--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -33,9 +33,10 @@ var Responder = (function(superClass) {
     "unsupported": "OP_UNSUPPORTED"
   };
 
-  function Responder(req1) {
+  function Responder(sftpStream1, req1) {
     var fn, methodname, ref, symbol;
     this.req = req1;
+    this.sftpStream = sftpStream1;
     ref = this.constructor.Statuses;
     fn = (function(_this) {
       return function(symbol) {
@@ -442,11 +443,11 @@ var SFTPSession = (function(superClass) {
   };
 
   SFTPSession.prototype.REMOVE = function(reqid, handle) {
-    return this.emit("delete", new Responder(reqid));
+    return this.emit("delete", new Responder(this.sftpStream, reqid));
   };
 
   SFTPSession.prototype.RENAME = function(reqid, oldPath, newPath) {
-    return this.emit("rename", oldPath, newPath, new Responder(reqid));
+    return this.emit("rename", oldPath, newPath, new Responder(this.sftpStream, reqid));
   };
 
   return SFTPSession;

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -64,7 +64,7 @@ var DirectoryEmitter = (function(superClass) {
     this.req = req1 != null ? req1 : null;
     this.stopped = false;
     this.done = false;
-    DirectoryEmitter.__super__.constructor.call(this, this.req);
+    DirectoryEmitter.__super__.constructor.call(this, sftpStream1, this.req);
   }
 
   DirectoryEmitter.prototype.request_directory = function(req) {


### PR DESCRIPTION
Whenever I tried calling `callback.ok()` or similar on `delete` or `rename` I got an error about `this.sftpStream` being undefined.

I followed the same convention used in the Statter object of passing in the stream as the first parameter. Seems to work now for me.