### PR TITLE
Possibility to set file attributes while emitting file(name, attrs) in readdir action

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ parameter, allowing you to respond with `responder.file(filename, attrs)` to ret
 a file entry in the directory, or `responder.end()` if the directory listing
 is complete.
 
+Some explanation on `attrs` param:
 ```js
-// Attrs object format could contain:
 var fs = require('fs');
 
 /*
-* Explanation for mode
+* Explanation for attrs.mode 
 * 
 * You may use type bit from fs lib constants and add permissions to it
 * 
@@ -163,13 +163,13 @@ var fs = require('fs');
 */
 
 var attrs = {
-	'mode': fs.constants.S_IFDIR | 0o644 // Bit mask of file type and permissions 
-	'permissions': 644, // Octal permissions, like what you'd send to a chmod command
-	'uid': 1, // User ID that owns the file.
-	'gid': 1, // Group ID that owns the file.
-	'size': 1234, // File size in bytes.
-	'atime': 123456, // Created at (unix style timestamp in seconds-from-epoch).
-	'mtime': 123456 // Modified at (unix style timestamp in seconds-from-epoch).
+	'mode': fs.constants.S_IFDIR | 0o644 	// Bit mask of file type and permissions 
+	'permissions': 644, 					// Octal permissions, like what you'd send to a chmod command
+	'uid': 1, 								// User ID that owns the file.
+	'gid': 1, 								// Group ID that owns the file.
+	'size': 1234, 							// File size in bytes.
+	'atime': 123456, 						// Created at (unix style timestamp in seconds-from-epoch).
+	'mtime': 123456 						// Modified at (unix style timestamp in seconds-from-epoch).
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -143,6 +143,37 @@ parameter, allowing you to respond with `responder.file(filename, attrs)` to ret
 a file entry in the directory, or `responder.end()` if the directory listing
 is complete.
 
+```js
+// Attrs object format could contain:
+var fs = require('fs');
+
+/*
+* Explanation for mode
+* 
+* You may use type bit from fs lib constants and add permissions to it
+* 
+* Permissions mask would look like 0oXXX where XXX is file octal permissions
+* 
+* If you'd like to explain directory use:
+* fs.constants.S_IFDIR | 0oXXX
+* 
+* If you'd like to explain file use:
+* fs.constants.S_IFREG | 0oXXX
+* 
+*/
+
+var attrs = {
+	'mode': fs.constants.S_IFDIR | 0o644 // Bit mask of file type and permissions 
+	'permissions': 644, // Octal permissions, like what you'd send to a chmod command
+	'uid': 1, // User ID that owns the file.
+	'gid': 1, // Group ID that owns the file.
+	'size': 1234, // File size in bytes.
+	'atime': 123456, // Created at (unix style timestamp in seconds-from-epoch).
+	'mtime': 123456 // Modified at (unix style timestamp in seconds-from-epoch).
+}
+
+```
+
 `.on("readfile",function (path,writable_stream) { })` - the client is attempting to read a file
 from the server - place or pipe the contents of the file into the `writable_stream`.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ session.on('stat', function(path, statkind, statresponder) {
 
 `.on("readdir",function (path,directory_emitter) { })` - on a directory listing attempt, the
 directory_emitter will keep emitting `dir` messages with a `responder` as a
-parameter, allowing you to respond with `responder.file(filename)` to return
+parameter, allowing you to respond with `responder.file(filename, attrs)` to return
 a file entry in the directory, or `responder.end()` if the directory listing
 is complete.
 

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -76,11 +76,14 @@ var DirectoryEmitter = (function(superClass) {
     }
   };
 
-  DirectoryEmitter.prototype.file = function(name) {
+  DirectoryEmitter.prototype.file = function(name, attrs) {
+    if(typeof attrs === 'undefined'){
+      attrs = {};
+    }
     this.stopped = this.sftpStream.name(this.req, {
       filename: name.toString(),
       longname: name.toString(),
-      attrs: {}
+      attrs: attrs
     });
     if (!this.stopped && !this.done) {
       return this.emit("dir");

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -77,7 +77,7 @@ var DirectoryEmitter = (function(superClass) {
   };
 
   DirectoryEmitter.prototype.file = function(name, attrs) {
-    if(typeof attrs === 'undefined'){
+    if (typeof attrs === 'undefined') {
       attrs = {};
     }
     this.stopped = this.sftpStream.name(this.req, {


### PR DESCRIPTION
I was creating my custom sftp <-> rest api realisation and found that I could not list files with correct types and permissions when creating listing with readdir action, so I made some changes to your library to make it work.
