### PR TITLE
Patch SSH error catching

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ as its parameter.
 
 `end` - emitted when the user disconnects from the server.
 
+`error` - emitted when the ssh server throws an error. passes error object
+
 ## Session Object
 
 This object is passed to you when you call `.accept(callback)` - your callback

--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -136,6 +136,10 @@ var SFTPServer = (function(superClass) {
       privateKey: fs.readFileSync(options.privateKeyFile)
     }, (function(_this) {
       return function(client, info) {
+        client.on('error', function(err) {
+          debug("SFTP Server: error");
+          return _this.emit("error", err);
+        });
         client.on('authentication', function(ctx) {
           debug("SFTP Server: on('authentication')");
           _this.auth_wrapper = new ContextWrapper(ctx, _this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-sftp-server",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Node.js SFTP Server bindings to implement your own SFTP Server",
   "main": "node-sftp-server.js",
   "scripts": {
@@ -15,6 +15,9 @@
     "sftp-server"
   ],
   "author": "Brady Wetherington <brady@briteverify.com>",
+  "contributors": [
+    "Jonathan Yarbor <jon@nodecraft.com> (https://nodecraft.com)"
+  ],
   "license": "ISC",
   "dependencies": {
     "ssh2": "^0.4.13",

--- a/server_example.js
+++ b/server_example.js
@@ -54,6 +54,9 @@ srv.on("connect", function(auth) {
   });
 });
 
+srv.on("error", function() {
+  return console.warn("Example server encountered an error");
+});
 srv.on("end", function() {
   return console.warn("Example says user disconnected");
 });


### PR DESCRIPTION
As mentioned in issue #30  the server doesn't gracefully handle errors
emitted from the SSH lib.

This change forces errors to bubble up to the main prototype.