### PR TITLE
Update to use more recent ssh2 library

### DIFF
--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -103,8 +103,8 @@ var ContextWrapper = (function() {
     this.password = this.ctx.password;
   }
 
-  ContextWrapper.prototype.reject = function() {
-    return this.ctx.reject();
+  ContextWrapper.prototype.reject = function(methodsLeft, isPartial) {
+    return this.ctx.reject(methodsLeft, isPartial);
   };
 
   ContextWrapper.prototype.accept = function(callback) {
@@ -133,7 +133,7 @@ var SFTPServer = (function(superClass) {
     }
     SFTPServer.options = options;
     this.server = new ssh2.Server({
-      privateKey: fs.readFileSync(options.privateKeyFile)
+      hostKeys: [fs.readFileSync(options.privateKeyFile)]
     }, (function(_this) {
       return function(client, info) {
         client.on('error', function(err) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "ssh2": "^0.4.13",
+    "ssh2": "0.5.x",
     "ssh2-streams": "^0.0.21",
     "tmp": "^0.0.30"
   },

--- a/server_example.js
+++ b/server_example.js
@@ -11,7 +11,7 @@ srv.listen(8022);
 srv.on("connect", function(auth) {
   console.warn("authentication attempted");
   if (auth.method !== 'password' || auth.username !== "brady" || auth.password !== "test") {
-    return auth.reject();
+    return auth.reject(['password']);
   }
   console.warn("We haven't *outhright* accepted yet...");
   var username = auth.username;


### PR DESCRIPTION
I found that the current version of this library is not well supported by Filezilla. Updating to ssh2 0.5.x helps, but there are a few other changes required to maintain compatibility with their changes.

Also, rejecting a connection that sends "none" as the first authentication type was failing as methodsLeft was not being passed through to ssh2's reject method. This is also addressed in this PR and the example server implements this too