### PR TITLE
Send client info after authentication

### DIFF
--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -143,7 +143,7 @@ var SFTPServer = (function(superClass) {
         client.on('authentication', function(ctx) {
           debug("SFTP Server: on('authentication')");
           _this.auth_wrapper = new ContextWrapper(ctx, _this);
-          return _this.emit("connect", _this.auth_wrapper);
+          return _this.emit("connect", _this.auth_wrapper, info);
         });
         client.on('end', function() {
           debug("SFTP Server: on('end')");


### PR DESCRIPTION
Useful to know about the client connecting either for debug or logging purposes.