### PR TITLE
adding SETSTAT to the accepted events

### DIFF
--- a/node-sftp-server.js
+++ b/node-sftp-server.js
@@ -237,7 +237,7 @@ var SFTPSession = (function(superClass) {
     "REALPATH", "STAT", "LSTAT", "FSTAT",
     "OPENDIR", "CLOSE", "REMOVE", "READDIR",
     "OPEN", "READ", "WRITE", "RENAME",
-    "MKDIR", "RMDIR"
+    "MKDIR", "RMDIR", "SETSTAT"
   ];
 
   function SFTPSession(sftpStream1) {
@@ -472,6 +472,10 @@ var SFTPSession = (function(superClass) {
 
   SFTPSession.prototype.RMDIR = function(reqid, path) {
     return this.emit("rmdir", path, new Responder(this.sftpStream, reqid));
+  };
+  
+  SFTPSession.prototype.SETSTAT = function(reqid, path) {
+    return this.emit("setstat", path, new Responder(this.sftpStream, reqid));
   };
 
   return SFTPSession;


### PR DESCRIPTION
SETSTAT is used by WINSCP when sending a file to SFTP server, if this event is not handled the upload is failed on the client side